### PR TITLE
Fix translation keys and close file

### DIFF
--- a/FreeSMS/__init__.py
+++ b/FreeSMS/__init__.py
@@ -9,8 +9,7 @@ app = Flask(
 )
 
 app.config.from_file(os.path.join(BASE, "../config.json"), load=json.load)
-app.config['TRANSLATIONS'] = json.load(
-    open(os.path.join(BASE, "../translations.json"), encoding="utf-8")
-)
+with open(os.path.join(BASE, "../translations.json"), encoding="utf-8") as fh:
+    app.config['TRANSLATIONS'] = json.load(fh)
 
 import FreeSMS.views

--- a/translations.json
+++ b/translations.json
@@ -51,6 +51,16 @@
   "no_modems_found": {
     "ru":"Модемы не найдены.","en":"No modems found.","zh":"未找到调制解调器。"
   },
+  "signal": {
+    "error": {"ru":"Нет данных","en":"No data","zh":"无数据"},
+    "none":  {"ru":"Нет сигнала","en":"No signal","zh":"无信号"},
+    "bad":   {"ru":"Плохой","en":"Bad","zh":"差"},
+    "medium":{"ru":"Средний","en":"Medium","zh":"中"},
+    "good":  {"ru":"Хороший","en":"Good","zh":"好"}
+  },
+  "status": {
+    "no_response": {"ru":"Нет ответа","en":"No response","zh":"无响应"}
+  },
   "rules_fields": {
     "pattern": { "ru":"Шаблон","en":"Pattern","zh":"模式" },
     "extract": { "ru":"Индекс","en":"Extract Index","zh":"提取索引" }


### PR DESCRIPTION
## Summary
- fix resource leak in __init__.py by opening translations.json with `with`
- add missing keys for modem status to translations.json

## Testing
- `python -m compileall -q FreeSMS`


------
https://chatgpt.com/codex/tasks/task_e_686c87ef7f4c832eac70f8278a0e202b