### PR TITLE
Display modem details after connect

### DIFF
--- a/static/js/contextMenu.js
+++ b/static/js/contextMenu.js
@@ -82,7 +82,11 @@ function hideContextMenu() {
 
 // Обновить строку после действия (stub)
 function updateRow(data) {
-  // здесь можно обновить конкретную строку с портом data.ports[0]
+  if (data && data.results) {
+    if (typeof window.updateRows === 'function') {
+      window.updateRows(data.results);
+    }
+  }
   console.log("Context action result:", data);
 }
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -74,6 +74,26 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   //
+  // Обновить строки таблицы данными модемов
+  //
+  function updateRows(results) {
+    Object.keys(results).forEach(port => {
+      const row = tbody.querySelector(`tr[data-port="${port}"]`);
+      if (!row) return;
+      const info = results[port];
+      Object.keys(labelsTrans).forEach(key => {
+        const cell = row.querySelector(`td.${key}`);
+        if (cell && info[key] !== undefined) {
+          cell.textContent = info[key];
+        }
+      });
+    });
+  }
+
+  // делаем функцию глобальной, чтобы её вызывал contextMenu.js
+  window.updateRows = updateRows;
+
+  //
   // Загрузить порты из API
   //
   function loadPorts() {
@@ -104,7 +124,7 @@ document.addEventListener('DOMContentLoaded', () => {
     .then(res => {
       // API на connect возвращает { success:true, results: {...} }
       if (action === 'connect' && res.results) {
-        // Можно отрисовать детали из res.results[port]
+        updateRows(res.results);
         log(`${action}: ${Object.keys(res.results).join(', ')}`);
       } else if (res.ports) {
         log(`${action}: ${res.ports.join(', ')}`);


### PR DESCRIPTION
## Summary
- show data from `/api/connect` in the modem table
- expose `updateRows` function for context menu use
- hook context menu to update the selected row

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686c8b8c9ef8832eae5e179cf1c08e63