### PR TITLE
Fix headers translation and add scroll

### DIFF
--- a/FreeSMS/views.py
+++ b/FreeSMS/views.py
@@ -22,9 +22,11 @@ def index():
     # сканируем все порты
     ports = list_modem_ports()
 
-    # локализованные заголовки таблицы
-    hdr_keys = list(current_app.config["TRANSLATIONS"]["table_headers"].keys())
-    labels   = {k: t(f"table_headers.{k}", lang) for k in hdr_keys}
+    # Заголовки таблицы: все переводы и текущий язык отдельно
+    translations = current_app.config["TRANSLATIONS"]["table_headers"]
+    hdr_keys = list(translations.keys())
+    labels_all = {k: translations[k] for k in hdr_keys}
+    labels_cur = {k: t(f"table_headers.{k}", lang) for k in hdr_keys}
 
     # кнопки и вкладки из конфигурации
     buttons = current_app.config["TRANSLATIONS"]["buttons"]
@@ -33,7 +35,8 @@ def index():
     return render_template(
         "index.html",
         ports=ports,
-        labels=labels,
+        labels=labels_cur,
+        labels_all=labels_all,
         buttons=buttons,
         tabs=tabs,
         lang=lang,
@@ -51,6 +54,7 @@ def phones():
         "phones.html",
         buttons=buttons,
         tabs=tabs,
+        labels_all=current_app.config["TRANSLATIONS"]["table_headers"],
         lang=lang,
         t=t
     )
@@ -65,6 +69,7 @@ def received():
         "received.html",
         buttons=buttons,
         tabs=tabs,
+        labels_all=current_app.config["TRANSLATIONS"]["table_headers"],
         lang=lang,
         t=t
     )
@@ -79,6 +84,7 @@ def sent():
         "sent.html",
         buttons=buttons,
         tabs=tabs,
+        labels_all=current_app.config["TRANSLATIONS"]["table_headers"],
         lang=lang,
         t=t
     )
@@ -94,6 +100,7 @@ def rules():
         rules_list=RULES,
         buttons=buttons,
         tabs=tabs,
+        labels_all=current_app.config["TRANSLATIONS"]["table_headers"],
         lang=lang,
         t=t
     )
@@ -108,6 +115,7 @@ def no_rules():
         "no_rules.html",
         buttons=buttons,
         tabs=tabs,
+        labels_all=current_app.config["TRANSLATIONS"]["table_headers"],
         lang=lang,
         t=t
     )
@@ -122,6 +130,7 @@ def forward():
         "forward.html",
         buttons=buttons,
         tabs=tabs,
+        labels_all=current_app.config["TRANSLATIONS"]["table_headers"],
         lang=lang,
         t=t
     )
@@ -136,6 +145,7 @@ def settings():
         "settings.html",
         buttons=buttons,
         tabs=tabs,
+        labels_all=current_app.config["TRANSLATIONS"]["table_headers"],
         lang=lang,
         t=t
     )

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -52,7 +52,7 @@ document.addEventListener('DOMContentLoaded', () => {
   //
   function renderTable() {
     tbody.innerHTML = '';
-    const subset = allPorts.slice(0, displayedCount);
+    const subset = allPorts;
     subset.forEach(port => {
       const tr = document.createElement('tr');
       tr.dataset.port = port;
@@ -70,7 +70,20 @@ document.addEventListener('DOMContentLoaded', () => {
       tr.innerHTML = html;
       tbody.appendChild(tr);
     });
-    log(`Rendered ${Math.min(displayedCount, allPorts.length)} of ${allPorts.length} ports`);
+    // Ограничиваем высоту таблицы 20 строками, если портов больше
+    const rows = tbody.querySelectorAll('tr');
+    const container = document.querySelector('section.modem-section');
+    if (rows.length && container) {
+      const rowHeight = rows[0].getBoundingClientRect().height;
+      if (rows.length > displayedCount) {
+        container.style.maxHeight = (rowHeight * displayedCount) + 'px';
+        container.style.overflowY = 'auto';
+      } else {
+        container.style.maxHeight = '';
+        container.style.overflowY = 'visible';
+      }
+    }
+    log(`Rendered ${subset.length} ports`);
   }
 
   //

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,8 +16,8 @@
       </thead>
       <tbody>
         {% if ports %}
-          {# Показываем первые 20 строк, остальные доступны по скроллу #}
-          {% for port in ports[:20] %}
+          {# Все строки, прокрутка ограничивает высоту таблицы #}
+          {% for port in ports %}
             <tr data-port="{{ port }}">
               <td><input type="checkbox" class="sel"></td>
               {% for key in labels.keys() %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -14,7 +14,7 @@
     window.lang    = "{{ lang }}";
     window.buttons = {{ buttons | tojson }};
     window.tabs    = {{ tabs    | tojson }};
-    window.labels  = {{ labels  | tojson }};
+    window.labels  = {{ labels_all | tojson }};
   </script>
 
   <!-- Скрипты -->


### PR DESCRIPTION
## Summary
- fix table header translations after language switch
- allow scrolling to show ports beyond the first 20

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686c8b41f460832eb88b7983207e9f75