### PR TITLE
Update table rendering

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -124,22 +124,6 @@ section.modem-section {
 #modem-table .sel {
   transform: scale(1.2);
 }
-#modem-table .row-actions button {
-  margin: 0 0.25rem;
-  padding: 0.25rem 0.5rem;
-  border: none;
-  background: #27ae60;
-  color: #fff;
-  cursor: pointer;
-  border-radius: 3px;
-  font-size: 0.8rem;
-}
-#modem-table .row-actions .btn-disconnect {
-  background: #c0392b;
-}
-#modem-table .row-actions button:hover {
-  opacity: 0.9;
-}
 
 /* Лог действий */
 #log-panel {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -52,21 +52,16 @@ document.addEventListener('DOMContentLoaded', () => {
   //
   function renderTable() {
     tbody.innerHTML = '';
-    const subset = allPorts;
+    const subset = allPorts.length ? allPorts : Array.from({length: displayedCount}, () => null);
     subset.forEach(port => {
       const tr = document.createElement('tr');
-      tr.dataset.port = port;
+      if (port) tr.dataset.port = port;
       let html = '';
-      html += `<td><input type="checkbox" class="sel"></td>`;
+      html += `<td><input type="checkbox" class="sel"${port ? '' : ' disabled'}></td>`;
       for (let key in labelsTrans) {
-        // порт — единственное поле, у остальных пока дефолт
-        const val = (key === 'port') ? port : '—';
+        const val = (key === 'port' && port) ? port : '—';
         html += `<td class="${key}">${val}</td>`;
       }
-      html += `<td class="row-actions">
-        <button class="btn-connect">${buttonsTrans.connect[currentLang]}</button>
-        <button class="btn-disconnect">${buttonsTrans.disconnect[currentLang]}</button>
-      </td>`;
       tr.innerHTML = html;
       tbody.appendChild(tr);
     });
@@ -191,16 +186,6 @@ document.addEventListener('DOMContentLoaded', () => {
     thead.querySelectorAll('th.sortable').forEach(th => {
       const key = th.dataset.key;
       th.textContent = labelsTrans[key][currentLang];
-    });
-    // Последний заголовок — «Действия»
-    const lastTh = thead.querySelector('th:last-child');
-    lastTh.textContent = `${buttonsTrans.connect[currentLang]}/${buttonsTrans.disconnect[currentLang]}`;
-    // Кнопки в строках
-    tbody.querySelectorAll('.btn-connect').forEach(btn => {
-      btn.textContent = buttonsTrans.connect[currentLang];
-    });
-    tbody.querySelectorAll('.btn-disconnect').forEach(btn => {
-      btn.textContent = buttonsTrans.disconnect[currentLang];
     });
   }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,6 @@
           {% for key, label in labels.items() %}
             <th class="sortable" data-key="{{ key }}">{{ label }}</th>
           {% endfor %}
-          <th>{{ buttons.connect[lang] }}/{{ buttons.disconnect[lang] }}</th>
         </tr>
       </thead>
       <tbody>
@@ -23,18 +22,17 @@
               {% for key in labels.keys() %}
                 <td class="{{ key }}">{{ key == 'port' and port or '—' }}</td>
               {% endfor %}
-              <td class="row-actions">
-                <button class="btn-connect">{{ buttons.connect[lang] }}</button>
-                <button class="btn-disconnect">{{ buttons.disconnect[lang] }}</button>
-              </td>
             </tr>
           {% endfor %}
         {% else %}
-          <tr>
-            <td colspan="{{ labels|length + 2 }}" class="no-modems">
-              {{ t("no_modems_found", lang) }}
-            </td>
-          </tr>
+          {% for _ in range(20) %}
+            <tr>
+              <td><input type="checkbox" class="sel" disabled></td>
+              {% for key in labels.keys() %}
+                <td class="{{ key }}">—</td>
+              {% endfor %}
+            </tr>
+          {% endfor %}
         {% endif %}
       </tbody>
     </table>


### PR DESCRIPTION
## Summary
- remove Connect/Disconnect buttons from modem table
- keep port data in correct column when rendering
- show 20 empty rows when no ports are detected
- clean up unused CSS

## Testing
- `python -m py_compile FreeSMS/*.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cf971cb60832ea0898d9695cfe59b