### PR TITLE
Fix column alignment issue

### DIFF
--- a/FreeSMS/views.py
+++ b/FreeSMS/views.py
@@ -37,6 +37,7 @@ def index():
         ports=ports,
         labels=labels_cur,
         labels_all=labels_all,
+        hdr_keys=hdr_keys,
         buttons=buttons,
         tabs=tabs,
         lang=lang,

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const buttonsTrans = window.buttons;    // из translations.json → buttons
   const tabsTrans    = window.tabs;       // из translations.json → tabs
   const labelsTrans  = window.labels;     // из translations.json → table_headers
+  const columnKeys   = (window.colKeys && window.colKeys.length) ? window.colKeys : Object.keys(labelsTrans);
   let currentLang    = window.lang || 'en';
 
   //
@@ -58,10 +59,10 @@ document.addEventListener('DOMContentLoaded', () => {
       if (port) tr.dataset.port = port;
       let html = '';
       html += `<td><input type="checkbox" class="sel"${port ? '' : ' disabled'}></td>`;
-      for (let key in labelsTrans) {
+      columnKeys.forEach(key => {
         const val = (key === 'port' && port) ? port : '—';
         html += `<td class="${key}">${val}</td>`;
-      }
+      });
       tr.innerHTML = html;
       tbody.appendChild(tr);
     });
@@ -93,10 +94,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const tr = document.createElement('tr');
         tr.dataset.port = port;
         let html = '<td><input type="checkbox" class="sel"></td>';
-        for (let key in labelsTrans) {
+        columnKeys.forEach(key => {
           const val = key === 'port' ? port : '—';
           html += `<td class="${key}">${val}</td>`;
-        }
+        });
         tr.innerHTML = html;
         tbody.appendChild(tr);
         row = tr;
@@ -111,7 +112,7 @@ document.addEventListener('DOMContentLoaded', () => {
         row = document.createElement('tr');
         row.dataset.port = port;
         let html = '<td><input type="checkbox" class="sel"></td>';
-        Object.keys(labelsTrans).forEach(key => {
+        columnKeys.forEach(key => {
           const val = key === 'port' ? port : (info[key] !== undefined ? info[key] : '—');
           html += `<td class="${key}">${val}</td>`;
         });
@@ -121,7 +122,7 @@ document.addEventListener('DOMContentLoaded', () => {
           allPorts.push(port);
         }
       } else {
-        Object.keys(labelsTrans).forEach(key => {
+        columnKeys.forEach(key => {
           const cell = row.querySelector(`td.${key}`);
           if (cell && info[key] !== undefined) {
             cell.textContent = info[key];

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,8 @@
         <tr>
           <th><input type="checkbox" id="select-all"></th>
           {# Заголовки столбцов из translations.json #}
-          {% for key, label in labels.items() %}
+          {% for key in hdr_keys %}
+            {% set label = labels[key] %}
             <th class="sortable" data-key="{{ key }}">{{ label }}</th>
           {% endfor %}
         </tr>
@@ -19,7 +20,7 @@
           {% for port in ports %}
             <tr data-port="{{ port }}">
               <td><input type="checkbox" class="sel"></td>
-              {% for key in labels.keys() %}
+              {% for key in hdr_keys %}
                 <td class="{{ key }}">{{ key == 'port' and port or '—' }}</td>
               {% endfor %}
             </tr>
@@ -28,7 +29,7 @@
           {% for _ in range(20) %}
             <tr>
               <td><input type="checkbox" class="sel" disabled></td>
-              {% for key in labels.keys() %}
+              {% for key in hdr_keys %}
                 <td class="{{ key }}">—</td>
               {% endfor %}
             </tr>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -15,6 +15,7 @@
     window.buttons = {{ buttons | tojson }};
     window.tabs    = {{ tabs    | tojson }};
     window.labels  = {{ labels_all | tojson }};
+    window.colKeys = {{ hdr_keys | tojson if hdr_keys is defined else '[]' }};
   </script>
 
   <!-- Скрипты -->


### PR DESCRIPTION
## Summary
- ensure header keys are explicitly ordered
- pass column order to layout
- loop over ordered keys when rendering table
- use column order in JS for updates

## Testing
- `python -m py_compile FreeSMS/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d0885b580832e9be8505433b001e7