### PR TITLE
Remove unused modal container

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -164,32 +164,6 @@ section.modem-section {
   white-space: pre-wrap;
 }
 
-/* Модальные окна */
-#modal-backdrop {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0,0,0,0.5);
-  z-index: 1000;
-}
-#modal-backdrop.hidden {
-  display: none;
-}
-#modal-container {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background: #fff;
-  padding: 1rem;
-  border-radius: 4px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
-  z-index: 1001;
-  min-width: 320px;
-  max-width: 90%;
-}
 
 /* Скроллбар (опционально) */
 #log-entries::-webkit-scrollbar,

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -57,8 +57,6 @@
     {% block content %}{% endblock %}
   </main>
 
-  <!-- Подложка и контейнер для модальных окон -->
-  <div id="modal-backdrop" class="hidden"></div>
-  <div id="modal-container"></div>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove modal container elements from the layout
- drop unused modal styles

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d0e0dfea0832e8e90fc511913c6e1