### PR TITLE
Implement streaming connect responses

### DIFF
--- a/FreeSMS/views.py
+++ b/FreeSMS/views.py
@@ -177,8 +177,39 @@ def api_modem_info():
     info = get_modem_info(port, get_language())
     return jsonify(info)
 
-@app.route("/api/connect", methods=["POST"])
+@app.route("/api/connect", methods=["GET", "POST"])
 def api_connect():
+    """Connect to selected ports and return modem info.
+
+    POST  - returns a single JSON object for all ports (legacy behaviour)
+    GET   - streams JSON objects per port via Server-Sent Events
+    """
+
+    if request.method == "GET":
+        # EventStream mode: ?ports=COM1&ports=COM2 or comma separated
+        ports = request.args.getlist("ports")
+        if not ports:
+            ports_arg = request.args.get("ports", "")
+            if ports_arg:
+                ports = [p.strip() for p in ports_arg.split(",") if p.strip()]
+        if not ports:
+            ports = list_modem_ports()
+
+        lang = request.cookies.get("lang", get_language())
+
+        def generate():
+            for p in ports:
+                try:
+                    info = get_modem_info(p, lang)
+                except Exception as e:
+                    info = {"port": p, "status": str(e)}
+                if "port" not in info:
+                    info["port"] = p
+                yield f"data: {json.dumps(info)}\n\n"
+
+        return current_app.response_class(generate(), mimetype="text/event-stream")
+
+    # POST behaviour - return aggregated JSON for all ports
     data = request.get_json(force=True) or {}
     sel = data.get("ports") or list_modem_ports()
     results = {}


### PR DESCRIPTION
## Summary
- add SSE support for `/api/connect`
- update JS to consume SSE events and update rows immediately

## Testing
- `python -m py_compile FreeSMS/views.py FreeSMS/modem_utils.py runserver.py`


------
https://chatgpt.com/codex/tasks/task_e_686d101564f4832ea3a7bb527220ab39