### PR TITLE
Implement streaming connect via POST

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -171,6 +171,60 @@ document.addEventListener('DOMContentLoaded', () => {
     const selected = Array.from(tbody.querySelectorAll('.sel:checked'))
                           .map(cb => cb.closest('tr').dataset.port);
     const ports = selected.length ? selected : allPorts;
+
+    if (action === 'connect') {
+      fetch('/api/connect', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'text/event-stream'
+        },
+        body: JSON.stringify({ ports })
+      })
+      .then(async res => {
+        if (res.ok && res.headers.get('Content-Type')?.startsWith('text/event-stream')) {
+          const reader = res.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = '';
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            let idx;
+            while ((idx = buffer.indexOf('\n\n')) !== -1) {
+              const chunk = buffer.slice(0, idx).trim();
+              buffer = buffer.slice(idx + 2);
+              if (chunk.startsWith('data:')) {
+                const data = chunk.slice(5).trim();
+                try {
+                  const info = JSON.parse(data);
+                  updateRows({ [info.port]: info });
+                  log(`connect: ${info.port}`);
+                } catch (e) {
+                  console.error(e);
+                }
+              }
+            }
+          }
+          return null; // streamed
+        }
+        return res.json();
+      })
+      .then(res => {
+        if (!res) return;
+        if (res.results) {
+          updateRows(res.results);
+          log(`connect: ${Object.keys(res.results).join(', ')}`);
+        } else if (res.ports) {
+          log(`${action}: ${res.ports.join(', ')}`);
+        } else {
+          log(`${action}: ${JSON.stringify(res)}`);
+        }
+      })
+      .catch(err => log(`connect error: ${err}`));
+      return;
+    }
+
     fetch(`/api/${action}`, {
       method: 'POST',
       headers: {'Content-Type':'application/json'},
@@ -178,11 +232,7 @@ document.addEventListener('DOMContentLoaded', () => {
     })
     .then(r => r.json())
     .then(res => {
-      // API на connect возвращает { success:true, results: {...} }
-      if (action === 'connect' && res.results) {
-        updateRows(res.results);
-        log(`${action}: ${Object.keys(res.results).join(', ')}`);
-      } else if (res.ports) {
+      if (res.ports) {
         log(`${action}: ${res.ports.join(', ')}`);
       } else {
         log(`${action}: ${JSON.stringify(res)}`);


### PR DESCRIPTION
## Summary
- stream `/api/connect` responses when `Accept: text/event-stream` header is sent
- update `doAction('connect')` to POST and parse streamed events

## Testing
- `python -m py_compile FreeSMS/views.py FreeSMS/modem_utils.py runserver.py`


------
https://chatgpt.com/codex/tasks/task_e_686d101564f4832ea3a7bb527220ab39