### PR TITLE
Fix docstring syntax error

### DIFF
--- a/FreeSMS/views.py
+++ b/FreeSMS/views.py
@@ -181,13 +181,10 @@ def api_modem_info():
 def api_connect():
     """Connect to selected ports and return modem info.
 
-
-    Accepts JSON ``{"ports": [..]}`` and returns modem info either as
-    a traditional aggregated JSON object or streams per-port results when the
+    Accepts JSON ``{"ports": [..]}`` and returns modem info either as a
+    traditional aggregated JSON object or streams per-port results when the
     client requests ``text/event-stream``.
-    """
 
-=======
     POST  - returns a single JSON object for all ports (legacy behaviour)
     GET   - streams JSON objects per port via Server-Sent Events
     """


### PR DESCRIPTION
## Summary
- close docstring in `api_connect`

## Testing
- `python -m py_compile FreeSMS/__init__.py FreeSMS/i18n.py FreeSMS/modem_utils.py FreeSMS/views.py runserver.py`

------
https://chatgpt.com/codex/tasks/task_e_686d190dad84832e9d018e343ff7ae06