### PR TITLE
Fix double request on connect

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -224,21 +224,7 @@ document.addEventListener('DOMContentLoaded', () => {
       })
       .catch(err => log(`connect error: ${err}`));
 
-      const params = new URLSearchParams();
-      ports.forEach(p => params.append('ports', p));
-      const es = new EventSource(`/api/connect?${params.toString()}`);
-      es.onmessage = ev => {
-        try {
-          const info = JSON.parse(ev.data);
-          updateRows({ [info.port]: info });
-          log(`connect: ${info.port}`);
-        } catch (e) {
-          console.error(e);
-        }
-      };
-      es.onerror = () => es.close();
-
-      return;
+      return; // handled via streamed POST response only
     }
 
     fetch(`/api/${action}`, {


### PR DESCRIPTION
## Summary
- avoid creating an extra `EventSource` when connecting so only the POST `/api/connect` happens

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d1a33ab80832e8be44f49acb47f42