### PR TITLE
Implement disconnect reset and phone field

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -64,6 +64,9 @@ nav.main-menu .menu-btn:hover {
 nav.main-menu .menu-btn:active {
   background: #1f6391;
 }
+nav.main-menu .menu-btn.active-state {
+  background: #1f6391;
+}
 
 /* Подменю (вкладки) */
 nav.tabs-menu {
@@ -177,4 +180,8 @@ section.modem-section::-webkit-scrollbar {
 section.modem-section::-webkit-scrollbar-thumb {
   background: #95a5a6;
   border-radius: 4px;
+}
+
+.hidden {
+  display: none !important;
 }

--- a/translations.json
+++ b/translations.json
@@ -19,6 +19,7 @@
     "imei":        { "ru":"IMEI","en":"IMEI","zh":"IMEI" },
     "iccid":       { "ru":"ICCID","en":"ICCID","zh":"ICCID" },
     "cpin":        { "ru":"CPIN","en":"CPIN","zh":"CPIN" },
+    "phone":       { "ru":"Телефон","en":"Phone","zh":"电话" },
     "ussd":        { "ru":"USSD","en":"USSD","zh":"USSD" }
   },
   "buttons": {


### PR DESCRIPTION
## Summary
- support `phone` table header with translations
- darken active connect/disconnect buttons
- add abort handling and clearing ports on disconnect
- style `.hidden`

## Testing
- `python -m py_compile FreeSMS/*.py runserver.py`

------
https://chatgpt.com/codex/tasks/task_e_686d1f08f180832ea91d0bf92e482cdd