### PR TITLE
Add phone field & continuous SIM checks

### DIFF
--- a/FreeSMS/modem_utils.py
+++ b/FreeSMS/modem_utils.py
@@ -142,6 +142,11 @@ def get_modem_info(port, lang=None):
     cpin = send_at_command(port, "AT+CPIN?").strip()
     info["cpin"] = cpin.replace("CPIN:", "").strip() if cpin else "—"
 
+    # Номер телефона SIM-карты
+    phone_resp = send_at_command(port, "AT+CNUM").strip()
+    m = re.search(r'"([+\\d]+)"', phone_resp)
+    info["phone"] = m.group(1) if m else "—"
+
     # Заглушки для SMS/Voice/USSD (реализуем позже)
     info["sms"] = 0
     info["voice"] = 0

--- a/FreeSMS/views.py
+++ b/FreeSMS/views.py
@@ -1,6 +1,7 @@
 # FreeSMS/views.py
 
 import json
+import time
 from flask import (
     render_template, request, jsonify, make_response, current_app
 )
@@ -202,14 +203,16 @@ def api_connect():
         lang = request.cookies.get("lang", get_language())
 
         def generate():
-            for p in ports:
-                try:
-                    info = get_modem_info(p, lang)
-                except Exception as e:
-                    info = {"port": p, "status": str(e)}
-                if "port" not in info:
-                    info["port"] = p
-                yield f"data: {json.dumps(info)}\n\n"
+            while True:
+                for p in ports:
+                    try:
+                        info = get_modem_info(p, lang)
+                    except Exception as e:
+                        info = {"port": p, "status": str(e)}
+                    if "port" not in info:
+                        info["port"] = p
+                    yield f"data: {json.dumps(info)}\n\n"
+                time.sleep(5)
 
         return current_app.response_class(generate(), mimetype="text/event-stream")
 
@@ -221,14 +224,16 @@ def api_connect():
     # Check if the client expects streaming responses
     if request.headers.get("Accept") == "text/event-stream":
         def generate():
-            for p in ports:
-                try:
-                    info = get_modem_info(p, lang)
-                except Exception as e:
-                    info = {"port": p, "status": str(e)}
-                if "port" not in info:
-                    info["port"] = p
-                yield f"data: {json.dumps(info)}\n\n"
+            while True:
+                for p in ports:
+                    try:
+                        info = get_modem_info(p, lang)
+                    except Exception as e:
+                        info = {"port": p, "status": str(e)}
+                    if "port" not in info:
+                        info["port"] = p
+                    yield f"data: {json.dumps(info)}\n\n"
+                time.sleep(5)
 
         return current_app.response_class(generate(), mimetype="text/event-stream")
 


### PR DESCRIPTION
## Summary
- extract phone number from modem
- continuously update modem info in `api_connect`
- support SSE polling by looping and sleeping

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `flake8` *(fails: command not found)*
- `ruff .` *(fails: unrecognized subcommand)*

------
https://chatgpt.com/codex/tasks/task_e_686d23f3988c832eb18c142210edbd34