### PR TITLE
Add column and table resizing

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -98,13 +98,14 @@ main#main-content {
 /* Таблица модемов */
 section.modem-section {
   width: 100%;
-  overflow-x: auto;
+  overflow: auto;
+  resize: vertical;
 }
 #modem-table {
   width: 100%;
   border-collapse: collapse;
   margin-top: 1rem;
-  table-layout: fixed; /* не растягиваем таблицу */
+  table-layout: fixed;
 }
 #modem-table thead {
   background: #34495e;
@@ -125,6 +126,18 @@ section.modem-section {
   white-space: normal;
   max-width: none;
   overflow: visible;
+}
+#modem-table th {
+  position: relative;
+}
+.col-resizer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 5px;
+  height: 100%;
+  cursor: col-resize;
+  user-select: none;
 }
 #modem-table th.sortable {
   cursor: pointer;
@@ -147,6 +160,8 @@ section.modem-section {
   padding: 0.75rem;
   background: #ecf0f1;
   border-top: 2px solid #ccc;
+  resize: vertical;
+  overflow: auto;
 }
 #log-panel .log-controls {
   display: flex;

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,12 @@
 {% block content %}
   <section id="tab-ports" class="modem-section">
     <table id="modem-table">
+      <colgroup>
+        <col class="col-select">
+        {% for key in hdr_keys %}
+        <col data-key="{{ key }}">
+        {% endfor %}
+      </colgroup>
       <thead>
         <tr>
           <th><input type="checkbox" id="select-all"></th>


### PR DESCRIPTION
## Summary
- make table and log panel vertically resizable
- add column resize handles in the modem table
- keep truncated text expandable while switching table layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d35c5120c832e96f17283da02ee30