### PR TITLE
Add disconnect cleanup and disable UI on disconnect

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -222,3 +222,12 @@ section.modem-section::-webkit-scrollbar-thumb {
 .hidden {
   display: none !important;
 }
+body.scripts-disabled * {
+  pointer-events: none;
+}
+body.scripts-disabled .sel,
+body.scripts-disabled #select-all,
+body.scripts-disabled nav.main-menu .menu-btn[data-action="connect"],
+body.scripts-disabled nav.main-menu .menu-btn[data-action="disconnect"] {
+  pointer-events: auto;
+}

--- a/static/js/contextMenu.js
+++ b/static/js/contextMenu.js
@@ -117,6 +117,7 @@ document.addEventListener("click", e => {
 
 // Перехватываем контекстное меню на строках таблицы
 document.addEventListener("contextmenu", e => {
+  if (window.scriptsDisabled) return;
   const row = e.target.closest("tr[data-port]");
   if (!row) return;
   e.preventDefault();

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -51,6 +51,19 @@ document.addEventListener('DOMContentLoaded', () => {
   let connectController = null;
   let expandedCount  = 0;
   let hiddenCols     = [];
+  let scriptsDisabled = false;
+
+  function setScriptsDisabled(state) {
+    scriptsDisabled = state;
+    document.body.classList.toggle('scripts-disabled', state);
+    window.scriptsDisabled = scriptsDisabled;
+  }
+
+  function clearModemData() {
+    portInfo = {};
+    localStorage.removeItem('portInfo');
+    renderTable();
+  }
 
   // Показываем/скрываем полное значение ячейки при клике
   table.addEventListener('click', e => {
@@ -244,6 +257,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const ports = selected.length ? selected : allPorts;
 
     if (action === 'connect') {
+      setScriptsDisabled(false);
       if (connectController) connectController.abort();
       connectController = new AbortController();
       connectBtn.classList.add('active-state');
@@ -310,6 +324,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       disconnectBtn.classList.add('active-state');
       connectBtn.classList.remove('active-state');
+      setScriptsDisabled(true);
     }
 
     fetch(`/api/${action}`, {
@@ -327,6 +342,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       if (action === 'disconnect') {
         log('disconnected');
+        clearModemData();
       }
     })
     .catch(err => log(`${action} error: ${err}`));
@@ -422,6 +438,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Сортировка по клику на шапку
   thead.addEventListener('click', e => {
+    if (scriptsDisabled) return;
     const th = e.target.closest('th.sortable');
     if (!th) return;
     sortBy(th.dataset.key);
@@ -597,6 +614,7 @@ document.addEventListener('DOMContentLoaded', () => {
   } catch (e) {}
 
   renderTable();
+  window.scriptsDisabled = scriptsDisabled;
   // Старт
   loadPorts();
   switchTab('ports');


### PR DESCRIPTION
## Summary
- clean modem table and disable interactive scripts when disconnecting
- allow only port selection and connect/disconnect buttons while disabled
- hide context menu when scripts are disabled

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d5001dab8832e8e31ebf6996ee1c2