### PR TITLE
Fix infinite connection stream and add port reload menu

### DIFF
--- a/FreeSMS/views.py
+++ b/FreeSMS/views.py
@@ -204,16 +204,14 @@ def api_connect():
         lang = request.cookies.get("lang", get_language())
 
         def generate():
-            while True:
-                for p in ports:
-                    try:
-                        info = get_modem_info(p, lang)
-                    except Exception as e:
-                        info = {"port": p, "status": str(e)}
-                    if "port" not in info:
-                        info["port"] = p
-                    yield f"data: {json.dumps(info)}\n\n"
-                time.sleep(0.5)
+            for p in ports:
+                try:
+                    info = get_modem_info(p, lang)
+                except Exception as e:
+                    info = {"port": p, "status": str(e)}
+                if "port" not in info:
+                    info["port"] = p
+                yield f"data: {json.dumps(info)}\n\n"
 
         return current_app.response_class(generate(), mimetype="text/event-stream")
 
@@ -225,16 +223,14 @@ def api_connect():
     # Check if the client expects streaming responses
     if request.headers.get("Accept") == "text/event-stream":
         def generate():
-            while True:
-                for p in ports:
-                    try:
-                        info = get_modem_info(p, lang)
-                    except Exception as e:
-                        info = {"port": p, "status": str(e)}
-                    if "port" not in info:
-                        info["port"] = p
-                    yield f"data: {json.dumps(info)}\n\n"
-                time.sleep(0.5)
+            for p in ports:
+                try:
+                    info = get_modem_info(p, lang)
+                except Exception as e:
+                    info = {"port": p, "status": str(e)}
+                if "port" not in info:
+                    info["port"] = p
+                yield f"data: {json.dumps(info)}\n\n"
 
         return current_app.response_class(generate(), mimetype="text/event-stream")
 


### PR DESCRIPTION
## Summary
- stop indefinite event stream in `/api/connect`
- include reload ports option in the context menu

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d5c41c0d0832e9b41c28d4a756404