### PR TITLE
Add table column controls and selective disconnect

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -166,6 +166,25 @@ section.modem-section {
   white-space: nowrap;
 }
 
+/* Кнопка управления столбцами справа от таблицы */
+.table-controls {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+}
+.table-controls .menu-btn {
+  background: #3498db;
+  border: none;
+  color: #fff;
+  padding: 0.4rem 0.6rem;
+  cursor: pointer;
+  border-radius: 3px;
+  font-size: 0.85rem;
+}
+.table-controls .menu-btn:hover {
+  background: #2980b9;
+}
+
 /* Лог действий */
 #log-panel {
   margin-top: 1.5rem;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -29,10 +29,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const fileLogCb       = document.getElementById('file-log');
   const logEntries      = document.getElementById('log-entries');
   const langBtns        = document.querySelectorAll('.lang-btn');
-  const menuBtns        = document.querySelectorAll('nav.main-menu .menu-btn');
+  const menuBtns        = document.querySelectorAll('.menu-btn');
   const connectBtn      = document.querySelector('nav.main-menu .menu-btn[data-action="connect"]');
   const disconnectBtn   = document.querySelector('nav.main-menu .menu-btn[data-action="disconnect"]');
-  const columnsBtn      = document.querySelector('nav.main-menu .menu-btn[data-action="columns"]');
+  const columnsBtns     = document.querySelectorAll('.menu-btn[data-action="columns"]');
   const tabBtns         = document.querySelectorAll('nav.tabs-menu .tab-btn');
   const contentSections = document.querySelectorAll('main#main-content section');
   const columnsPanel    = document.getElementById('columns-panel');
@@ -59,9 +59,18 @@ document.addEventListener('DOMContentLoaded', () => {
     window.scriptsDisabled = scriptsDisabled;
   }
 
-  function clearModemData() {
-    portInfo = {};
-    localStorage.removeItem('portInfo');
+  function clearModemData(selPorts = null) {
+    if (Array.isArray(selPorts) && selPorts.length) {
+      selPorts.forEach(p => {
+        delete portInfo[p];
+        allPorts = allPorts.filter(port => port !== p);
+      });
+      localStorage.setItem('portInfo', JSON.stringify(portInfo));
+    } else {
+      portInfo = {};
+      allPorts = [];
+      localStorage.removeItem('portInfo');
+    }
     renderTable();
   }
 
@@ -342,7 +351,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       if (action === 'disconnect') {
         log('disconnected');
-        clearModemData();
+        clearModemData(ports);
       }
     })
     .catch(err => log(`${action} error: ${err}`));
@@ -409,7 +418,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // Главное меню
     menuBtns.forEach(b => {
       const act = b.dataset.action;
-      b.textContent = buttonsTrans[act][currentLang];
+      if (act && buttonsTrans[act]) {
+        b.textContent = buttonsTrans[act][currentLang];
+      }
     });
     // Вкладки
     tabBtns.forEach(b => {
@@ -454,12 +465,14 @@ document.addEventListener('DOMContentLoaded', () => {
       .addEventListener('click', () => alert(`${act} not implemented yet`));
   });
 
-  if (columnsBtn && columnsPanel) {
-    columnsBtn.addEventListener('click', () => {
-      if (columnsPanel.classList.contains('hidden')) {
-        initColumnPanel();
-      }
-      columnsPanel.classList.toggle('hidden');
+  if (columnsBtns.length && columnsPanel) {
+    columnsBtns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        if (columnsPanel.classList.contains('hidden')) {
+          initColumnPanel();
+        }
+        columnsPanel.classList.toggle('hidden');
+      });
     });
 
     columnsPanel.addEventListener('change', e => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -43,6 +43,9 @@
         {% endif %}
       </tbody>
     </table>
+    <div class="table-controls">
+      <button class="menu-btn" id="columns-table-btn" data-action="columns">{{ buttons.columns[lang] }}</button>
+    </div>
     <div id="columns-panel" class="hidden column-panel"></div>
   </section>
 


### PR DESCRIPTION
## Summary
- allow disconnecting only selected ports instead of clearing all
- add column settings button next to table
- style the new button
- support multiple column control buttons in JS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d62039f58832ea45c65cbc0c6b455