### PR TITLE
Update column button placement

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -170,7 +170,7 @@ section.modem-section {
 .table-controls {
   display: flex;
   justify-content: flex-end;
-  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 .table-controls .menu-btn {
   background: #3498db;

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,9 @@
 
 {% block content %}
   <section id="tab-ports" class="modem-section">
+    <div class="table-controls">
+      <button class="menu-btn" id="columns-table-btn" data-action="columns">{{ buttons.columns[lang] }}</button>
+    </div>
     <table id="modem-table">
       <colgroup>
         <col class="col-select">
@@ -43,9 +46,6 @@
         {% endif %}
       </tbody>
     </table>
-    <div class="table-controls">
-      <button class="menu-btn" id="columns-table-btn" data-action="columns">{{ buttons.columns[lang] }}</button>
-    </div>
     <div id="columns-panel" class="hidden column-panel"></div>
   </section>
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -42,7 +42,6 @@
     <button class="menu-btn" data-action="ussd">{{ buttons.ussd[lang] }}</button>
     <button class="menu-btn" data-action="port_find">{{ buttons.port_find[lang] }}</button>
     <button class="menu-btn" data-action="port_sort">{{ buttons.port_sort[lang] }}</button>
-    <button class="menu-btn" data-action="columns">{{ buttons.columns[lang] }}</button>
     <button class="menu-btn" data-action="settings">{{ buttons.settings[lang] }}</button>
   </nav>
 


### PR DESCRIPTION
## Summary
- move the columns button above the table
- remove columns button from the main menu
- tweak table-controls margin

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686d66cce3b0832e9f246d9e188d5792