### PR TITLE
Show column selector above table

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -159,7 +159,7 @@ section.modem-section {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
   font-size: 0.85rem;
 }
 .column-panel label {

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,7 @@
     <div class="table-controls">
       <button class="menu-btn" id="columns-table-btn" data-action="columns">{{ buttons.columns[lang] }}</button>
     </div>
+    <div id="columns-panel" class="hidden column-panel"></div>
     <table id="modem-table">
       <colgroup>
         <col class="col-select">
@@ -46,7 +47,6 @@
         {% endif %}
       </tbody>
     </table>
-    <div id="columns-panel" class="hidden column-panel"></div>
   </section>
 
   {# Лог действий и управление #}


### PR DESCRIPTION
## Summary
- place the column selector panel above the table
- adjust styling so the panel has bottom margin

## Testing
- `python -m py_compile FreeSMS/*.py runserver.py`

------
https://chatgpt.com/codex/tasks/task_e_686d69799bd8832eb3bdf2b82fc3c25d