### PR TITLE
Fix context menu after disconnect

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -250,3 +250,9 @@ body.scripts-disabled nav.main-menu .menu-btn[data-action="connect"],
 body.scripts-disabled nav.main-menu .menu-btn[data-action="disconnect"] {
   pointer-events: auto;
 }
+body.scripts-disabled #modem-table tbody,
+body.scripts-disabled #modem-table tbody *,
+body.scripts-disabled #context-menu,
+body.scripts-disabled #context-menu * {
+  pointer-events: auto;
+}

--- a/static/js/contextMenu.js
+++ b/static/js/contextMenu.js
@@ -117,7 +117,6 @@ document.addEventListener("click", e => {
 
 // Перехватываем контекстное меню на строках таблицы
 document.addEventListener("contextmenu", e => {
-  if (window.scriptsDisabled) return;
   const row = e.target.closest("tr[data-port]");
   if (!row) return;
   e.preventDefault();


### PR DESCRIPTION
## Summary
- prevent disconnect from disabling context menu
- allow pointer events on table and context menu even when scripts are disabled

## Testing
- `python -m py_compile FreeSMS/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686d71f981f4832e9fc968ce330e05f5