### PR TITLE
Add live modem monitor

### DIFF
--- a/static/js/contextMenu.js
+++ b/static/js/contextMenu.js
@@ -61,7 +61,17 @@ function showContextMenu(x, y, port, buttons, lang) {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ ports: [port] })
-        }).then(r => r.json()).then(updateRow);
+        })
+        .then(r => r.json())
+        .then(data => {
+          updateRow(data);
+          if (action === "connect" && typeof window.startMonitoring === 'function') {
+            window.startMonitoring([port]);
+          }
+          if (action === "disconnect" && typeof window.stopMonitoring === 'function') {
+            window.stopMonitoring();
+          }
+        });
       } else if (action === "ussd") {
         openUSSDModal([port]);
       } else if (action === "port_find") {


### PR DESCRIPTION
## Summary
- stream modem state updates via `/api/monitor`
- add EventSource client to watch port changes
- expose monitor start/stop globally and integrate with connect/disconnect actions
- hook context menu actions to monitoring

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686db74219b0832eb037296bd6ddcafd