### PR TITLE
Add asyncio modem polling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask>=2.0
 pyserial>=3.5
+pyserial-asyncio>=0.6
 pycountry>=24.6.1
 requests>=2.0


### PR DESCRIPTION
## Summary
- add async serial communication helpers
- enable async modem info retrieval
- update monitor API to use asyncio
- include pyserial-asyncio in dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dbdfd1658832e9214beded26a67a7