### PR TITLE
Improve modem monitor diffing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyserial>=3.5
 pyserial-asyncio>=0.6
 pycountry>=24.6.1
 requests>=2.0
+deepdiff>=6.0


### PR DESCRIPTION
## Summary
- use DeepDiff to detect changes in `/api/monitor`
- add DeepDiff to requirements

## Testing
- `python -m compileall -q FreeSMS`
- `python runserver.py --help` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686dc116d7bc832eb65be5f79b6dc792