### PR TITLE
Handle disappearing ports in monitor

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -218,7 +218,16 @@ document.addEventListener('DOMContentLoaded', () => {
   function updateRows(results) {
     let added = false;
     let changed = false;
+    let removed = false;
     Object.keys(results).forEach(port => {
+      if (results[port].removed) {
+        const row = tbody.querySelector(`tr[data-port="${port}"]`);
+        if (row) row.remove();
+        delete portInfo[port];
+        allPorts = allPorts.filter(p => p !== port);
+        removed = true;
+        return;
+      }
       let row = tbody.querySelector(`tr[data-port="${port}"]`);
       const current = portInfo[port] || {};
       portInfo[port] = Object.assign({}, current, results[port], { port });
@@ -285,7 +294,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       }
     }
-    if (added || changed) {
+    if (added || changed || removed) {
       localStorage.setItem('portInfo', JSON.stringify(portInfo));
     }
   }


### PR DESCRIPTION
## Summary
- detect missing ports/SIMs in SSE monitor endpoint
- emit `removed: true` SSE messages
- handle removal in frontend table
- preserve previous info if a port raises an error

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686dcff1f204832e91171957524cca96