### PR TITLE
Add port polling data logging

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -232,6 +232,14 @@ document.addEventListener('DOMContentLoaded', () => {
       const current = portInfo[port] || {};
       portInfo[port] = Object.assign({}, current, results[port], { port });
 
+      if (fileLogCb.checked) {
+        fetch('/api/log', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: JSON.stringify(portInfo[port]), port })
+        }).catch(() => {});
+      }
+
       if (!row) {
         const tr = document.createElement('tr');
         tr.dataset.port = port;


### PR DESCRIPTION
## Summary
- log entire port information in JS when log-to-file option is enabled

## Testing
- `python -m py_compile FreeSMS/*.py runserver.py`

------
https://chatgpt.com/codex/tasks/task_e_686ddafcb03c832e9edd630c42114fae